### PR TITLE
No need to modify core to integrate with wora/cache-persist

### DIFF
--- a/examples/90_wora_persist/package.json
+++ b/examples/90_wora_persist/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "redux-in-worker-example",
+  "version": "0.1.0",
+  "private": true,
+  "dependencies": {
+    "@wora/cache-persist": "^1.1.0",
+    "react": "latest",
+    "react-dom": "latest",
+    "react-redux": "latest",
+    "react-scripts": "^2.1.1",
+    "redux": "latest",
+    "redux-in-worker": "latest"
+  },
+  "scripts": {
+    "start": "react-scripts start",
+    "build": "react-scripts build",
+    "test": "react-scripts test",
+    "eject": "react-scripts eject"
+  },
+  "browserslist": [
+    ">0.2%",
+    "not dead",
+    "not ie <= 11",
+    "not op_mini all"
+  ]
+}

--- a/examples/90_wora_persist/public/index.html
+++ b/examples/90_wora_persist/public/index.html
@@ -1,0 +1,8 @@
+<html>
+  <head>
+    <title>redux-in-worker example</title>
+  </head>
+  <body>
+    <div id="app"></div>
+  </body>
+</html>

--- a/examples/90_wora_persist/src/index.js
+++ b/examples/90_wora_persist/src/index.js
@@ -1,0 +1,36 @@
+import React, { StrictMode } from 'react';
+import ReactDOM from 'react-dom';
+import { Provider, useDispatch, useSelector } from 'react-redux';
+
+import { wrapStore } from 'redux-in-worker';
+
+import { initialState } from './store.worker';
+
+const store = wrapStore(
+  new Worker('./store.worker', { type: 'module' }),
+  initialState,
+  window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__(),
+);
+
+const Counter = () => {
+  const dispatch = useDispatch();
+  const count = useSelector(state => state.count);
+  return (
+    <div>
+      count: {count}
+      <button type="button" onClick={() => dispatch({ type: 'increment' })}>+1</button>
+      <button type="button" onClick={() => dispatch({ type: 'decrement' })}>-1</button>
+    </div>
+  );
+};
+
+const App = () => (
+  <StrictMode>
+    <Provider store={store}>
+      <Counter />
+      <Counter />
+    </Provider>
+  </StrictMode>
+);
+
+ReactDOM.render(<App />, document.getElementById('app'));

--- a/examples/90_wora_persist/src/store.worker.js
+++ b/examples/90_wora_persist/src/store.worker.js
@@ -1,0 +1,44 @@
+import { createStore } from 'redux';
+import Cache from '@wora/cache-persist';
+import IDBStorage from '@wora/cache-persist/lib/idbstorage';
+
+import { exposeStore } from 'redux-in-worker';
+
+export const initialState = { count: 0 };
+const reducer = (state = initialState, action) => {
+  switch (action.type) {
+    case 'increment':
+      return { ...state, count: state.count + 1 };
+    case 'decrement':
+      return { ...state, count: state.count - 1 };
+    default:
+      return state;
+  }
+};
+
+const idbStorages = IDBStorage.create({
+  name: 'redux',
+  storeNames: ['persist'],
+});
+
+const persistOptions = {
+  storage: idbStorages[0],
+  serialize: false,
+};
+
+const cache = new Cache(persistOptions);
+
+const isEmpty = obj => !Object.keys(obj).length;
+
+cache.restore().then(() => {
+  const preloadedState = isEmpty(cache.getState()) ? initialState : cache.getState();
+  const store = createStore(reducer, preloadedState);
+  const listener = () => {
+    const state = store.getState();
+    Object.keys(state).forEach((key) => {
+      cache.set(key, state[key]);
+    });
+  };
+  store.subscribe(listener);
+  exposeStore(store);
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1563,6 +1563,15 @@
         "@xtuc/long": "4.2.2"
       }
     },
+    "@wora/cache-persist": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@wora/cache-persist/-/cache-persist-1.1.0.tgz",
+      "integrity": "sha512-Is8KezUSuB8W0Q+1bjv1aPxVzyOKYzxETcWoqTmo1eN4DBXFY3ifY7YTR2F7em27uwgFuq4DHCA6ykYfy49tww==",
+      "dev": true,
+      "requires": {
+        "idb": "^4.0.0"
+      }
+    },
     "@xtuc/ieee754": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
@@ -5419,6 +5428,12 @@
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
+    },
+    "idb": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/idb/-/idb-4.0.4.tgz",
+      "integrity": "sha512-ZYsaBSNub2yAnjvmRKudQlMIPqZQIefAOwNIPeXC+RLIeXYFc0UNQqONKNuQeBNf8oBOV5L75yJ9zFISjHVj4g==",
+      "dev": true
     },
     "ieee754": {
       "version": "1.1.13",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "tsc-test": "tsc --project . --noEmit",
     "examples:minimal": "DIR=01_minimal EXT=js webpack-dev-server",
     "examples:typescript": "DIR=02_typescript webpack-dev-server",
-    "examples:router": "DIR=03_router webpack-dev-server"
+    "examples:router": "DIR=03_router webpack-dev-server",
+    "examples:wora_persist": "DIR=90_wora_persist EXT=js webpack-dev-server"
   },
   "keywords": [
     "redux",
@@ -46,6 +47,7 @@
     "@types/react-router-dom": "^4.3.4",
     "@typescript-eslint/eslint-plugin": "^2.0.0",
     "@typescript-eslint/parser": "^2.0.0",
+    "@wora/cache-persist": "^1.1.0",
     "babel-core": "^7.0.0-bridge.0",
     "babel-eslint": "^10.0.2",
     "babel-loader": "^8.0.6",


### PR DESCRIPTION
redux is so extensible that you don't need to modify the core. so is redux-in-worker.
This example shows how to integrate cache-persist with redux-in-worker.
(BTW, if we integrate it with the bare redux, we would need to implement an enhancer.)